### PR TITLE
Fix unimplemented multi actionkey words

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
     "ID":"F737A9223560B3C6833B5FFB8CDF78E5",
-    "ActionKeywords": [ "*", "<"],
+    "ActionKeywords": ["*"],
     "Name":"Window Walker",
     "Description":"Alt-Tab alternative enabling searching through your windows.",
     "Author":"betadele",
-    "Version":"1.0.0",
+    "Version":"1.0.1",
     "Language":"csharp",
     "Website":"https://www.windowwalker.com/",
     "ExecuteFileName":"Microsoft.Plugin.WindowWalker.dll",


### PR DESCRIPTION
Multi actionkeywords is not implemented in this plugin, which causes the settings window not showing the option to change action keyword.

This PR removes the additional action keyword