### PR TITLE
Output all process on query

### DIFF
--- a/Components/SearchController.cs
+++ b/Components/SearchController.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
 
             if (string.IsNullOrWhiteSpace(SearchText))
             {
-                searchMatches = new List<SearchResult>();
+                searchMatches = snapshotOfOpenWindows.Select(x => new SearchResult { Result = x}).ToList();
             }
             else
             {

--- a/Components/SearchResult.cs
+++ b/Components/SearchResult.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         public Window Result
         {
             get;
-            private set;
+            internal set;
         }
 
         /// <summary>
@@ -79,6 +79,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
             SearchResultMatchType = matchType;
             CalculateScore();
         }
+
+        public SearchResult() { }
 
         /// <summary>
         /// Calculates the score for how closely this window matches the search string

--- a/plugin.json
+++ b/plugin.json
@@ -1,10 +1,10 @@
 {
     "ID":"F737A9223560B3C6833B5FFB8CDF78E5",
-    "ActionKeywords": [ "*", "<"],
+    "ActionKeywords": ["*"],
     "Name":"Window Walker",
     "Description":"Alt-Tab alternative enabling searching through your windows.",
     "Author":"betadele",
-    "Version":"1.0.0",
+    "Version":"1.0.1",
     "Language":"csharp",
     "Website":"https://www.windowwalker.com/",
     "ExecuteFileName":"Microsoft.Plugin.WindowWalker.dll",

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name":"Window Walker",
     "Description":"Alt-Tab alternative enabling searching through your windows.",
     "Author":"betadele",
-    "Version":"1.0.1",
+    "Version":"1.1.0",
     "Language":"csharp",
     "Website":"https://www.windowwalker.com/",
     "ExecuteFileName":"Microsoft.Plugin.WindowWalker.dll",


### PR DESCRIPTION
List all processes when queried by an action keyword so users can still scroll through the list even if the search text is not there. Helps if unsure what text to search for initially.