### PR TITLE
Fix owner mis check

### DIFF
--- a/Components/OpenWindows.cs
+++ b/Components/OpenWindows.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         public void UpdateOpenWindowsList()
         {
             windows.Clear();
-            NativeMethods.CallBackPtr callbackptr = new NativeMethods.CallBackPtr(WindowEnumerationCallBack);
+            NativeMethods.CallBackPtr callbackptr = WindowEnumerationCallBack;
             _ = NativeMethods.EnumWindows(callbackptr, 0);
         }
 

--- a/Components/Window.cs
+++ b/Components/Window.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 // Code forked from Betsegaw Tadele's https://github.com/betsegaw/windowwalker/
+
 using Flow.Launcher.Plugin;
 using Microsoft.Plugin.WindowWalker.Views;
 using System;
@@ -112,19 +113,20 @@ namespace Microsoft.Plugin.WindowWalker.Components
                     {
                         new Task(() =>
                         {
-                            NativeMethods.CallBackPtr callbackptr = new NativeMethods.CallBackPtr((IntPtr hwnd, IntPtr lParam) =>
-                            {
-                                var childProcessId = GetProcessIDFromWindowHandle(hwnd);
-                                if (childProcessId != ProcessID)
+                            NativeMethods.CallBackPtr callbackptr = new NativeMethods.CallBackPtr(
+                                (IntPtr hwnd, IntPtr lParam) =>
                                 {
-                                    _handlesToProcessCache[Hwnd] = GetProcessNameFromWindowHandle(hwnd);
-                                    return false;
-                                }
-                                else
-                                {
-                                    return true;
-                                }
-                            });
+                                    var childProcessId = GetProcessIDFromWindowHandle(hwnd);
+                                    if (childProcessId != ProcessID)
+                                    {
+                                        _handlesToProcessCache[Hwnd] = GetProcessNameFromWindowHandle(hwnd);
+                                        return false;
+                                    }
+                                    else
+                                    {
+                                        return true;
+                                    }
+                                });
                             _ = NativeMethods.EnumChildWindows(Hwnd, callbackptr, 0);
                         }).Start();
                     }
@@ -140,8 +142,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
             {
                 new Result
                 {
-                    Title="Create Quick Access for this window",
-                    IcoPath= Main.IconPath,
+                    Title = "Create Quick Access for this window",
+                    IcoPath = Main.IconPath,
                     Action = _ =>
                     {
                         var quickAccessAssign = new QuickAccessKeywordAssignedWindow(this);
@@ -160,7 +162,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
             get
             {
                 StringBuilder windowClassName = new StringBuilder(300);
-                var numCharactersWritten = NativeMethods.GetClassName(Hwnd, windowClassName, windowClassName.MaxCapacity);
+                var numCharactersWritten =
+                    NativeMethods.GetClassName(Hwnd, windowClassName, windowClassName.MaxCapacity);
 
                 if (numCharactersWritten == 0)
                 {
@@ -176,10 +179,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// </summary>
         public bool Visible
         {
-            get
-            {
-                return NativeMethods.IsWindowVisible(Hwnd);
-            }
+            get { return NativeMethods.IsWindowVisible(Hwnd); }
         }
 
         /// <summary>
@@ -187,10 +187,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// </summary>
         public bool IsWindow
         {
-            get
-            {
-                return NativeMethods.IsWindow(Hwnd);
-            }
+            get { return NativeMethods.IsWindow(Hwnd); }
         }
 
         /// <summary>
@@ -201,8 +198,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
             get
             {
                 return (NativeMethods.GetWindowLong(Hwnd, NativeMethods.GWL_EXSTYLE) &
-                    (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW) ==
-                    (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW;
+                        (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW) ==
+                       (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW;
             }
         }
 
@@ -214,8 +211,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
             get
             {
                 return (NativeMethods.GetWindowLong(Hwnd, NativeMethods.GWL_EXSTYLE) &
-                    (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW) ==
-                    (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW;
+                        (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW) ==
+                       (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW;
             }
         }
 
@@ -224,10 +221,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// </summary>
         public bool TaskListDeleted
         {
-            get
-            {
-                return NativeMethods.GetProp(Hwnd, "ITaskList_Deleted") != IntPtr.Zero;
-            }
+            get { return NativeMethods.GetProp(Hwnd, "ITaskList_Deleted") != IntPtr.Zero; }
         }
 
         /// <summary>
@@ -237,7 +231,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
         {
             get
             {
-                return NativeMethods.GetWindow(Hwnd, NativeMethods.GetWindowCmd.GW_OWNER) != IntPtr.Zero;
+                var owner = NativeMethods.GetWindow(Hwnd, NativeMethods.GetWindowCmd.GW_OWNER);
+                return owner == IntPtr.Zero || owner == Hwnd;
             }
         }
 
@@ -246,10 +241,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// </summary>
         public bool Minimized
         {
-            get
-            {
-                return GetWindowSizeState() == WindowSizeState.Minimized;
-            }
+            get { return GetWindowSizeState() == WindowSizeState.Minimized; }
         }
 
         /// <summary>
@@ -315,7 +307,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
                 case NativeMethods.ShowWindowCommands.Minimize:
                 case NativeMethods.ShowWindowCommands.ShowMinimized:
                     return WindowSizeState.Minimized;
-                case NativeMethods.ShowWindowCommands.Maximize: // No need for ShowMaximized here since its also of value 3
+                case NativeMethods.ShowWindowCommands.Maximize
+                    : // No need for ShowMaximized here since its also of value 3
                     return WindowSizeState.Maximized;
                 default:
                     // throw new Exception("Don't know how to handle window state = " + placement.ShowCmd);
@@ -343,7 +336,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
         {
             uint processId = GetProcessIDFromWindowHandle(hwnd);
             ProcessID = processId;
-            IntPtr processHandle = NativeMethods.OpenProcess(NativeMethods.ProcessAccessFlags.AllAccess, true, (int)processId);
+            IntPtr processHandle =
+                NativeMethods.OpenProcess(NativeMethods.ProcessAccessFlags.AllAccess, true, (int)processId);
             StringBuilder processName = new StringBuilder(MaximumFileNameLength);
 
             if (NativeMethods.GetProcessImageFileName(processHandle, processName, MaximumFileNameLength) != 0)

--- a/Components/Window.cs
+++ b/Components/Window.cs
@@ -71,10 +71,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// <summary>
         /// Gets the handle to the window
         /// </summary>
-        public IntPtr Hwnd
-        {
-            get { return hwnd; }
-        }
+        public IntPtr Hwnd => hwnd;
 
         public uint ProcessID { get; set; }
 
@@ -177,52 +174,33 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// <summary>
         /// Gets a value indicating whether is the window visible (might return false if it is a hidden IE tab)
         /// </summary>
-        public bool Visible
-        {
-            get { return NativeMethods.IsWindowVisible(Hwnd); }
-        }
+        public bool Visible => NativeMethods.IsWindowVisible(Hwnd);
 
         /// <summary>
         /// Gets a value indicating whether determines whether the specified window handle identifies an existing window.
         /// </summary>
-        public bool IsWindow
-        {
-            get { return NativeMethods.IsWindow(Hwnd); }
-        }
+        public bool IsWindow => NativeMethods.IsWindow(Hwnd);
 
         /// <summary>
         /// Gets a value indicating whether get a value indicating whether is the window GWL_EX_STYLE is a toolwindow
         /// </summary>
-        public bool IsToolWindow
-        {
-            get
-            {
-                return (NativeMethods.GetWindowLong(Hwnd, NativeMethods.GWL_EXSTYLE) &
-                        (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW) ==
-                       (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW;
-            }
-        }
+        public bool IsToolWindow =>
+            (NativeMethods.GetWindowLong(Hwnd, NativeMethods.GWL_EXSTYLE) &
+             (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW) ==
+            (uint)NativeMethods.ExtendedWindowStyles.WS_EX_TOOLWINDOW;
 
         /// <summary>
         /// Gets a value indicating whether get a value indicating whether the window GWL_EX_STYLE is an appwindow
         /// </summary>
-        public bool IsAppWindow
-        {
-            get
-            {
-                return (NativeMethods.GetWindowLong(Hwnd, NativeMethods.GWL_EXSTYLE) &
-                        (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW) ==
-                       (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW;
-            }
-        }
+        public bool IsAppWindow =>
+            (NativeMethods.GetWindowLong(Hwnd, NativeMethods.GWL_EXSTYLE) &
+             (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW) ==
+            (uint)NativeMethods.ExtendedWindowStyles.WS_EX_APPWINDOW;
 
         /// <summary>
         /// Gets a value indicating whether get a value indicating whether the window has ITaskList_Deleted property
         /// </summary>
-        public bool TaskListDeleted
-        {
-            get { return NativeMethods.GetProp(Hwnd, "ITaskList_Deleted") != IntPtr.Zero; }
-        }
+        public bool TaskListDeleted => NativeMethods.GetProp(Hwnd, "ITaskList_Deleted") != IntPtr.Zero;
 
         /// <summary>
         /// Gets a value indicating whether determines whether the specified windows is the owner
@@ -239,10 +217,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// <summary>
         /// Gets a value indicating whether returns true if the window is minimized
         /// </summary>
-        public bool Minimized
-        {
-            get { return GetWindowSizeState() == WindowSizeState.Minimized; }
-        }
+        public bool Minimized => GetWindowSizeState() == WindowSizeState.Minimized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Window"/> class.

--- a/Components/Window.cs
+++ b/Components/Window.cs
@@ -282,8 +282,8 @@ namespace Microsoft.Plugin.WindowWalker.Components
                 case NativeMethods.ShowWindowCommands.Minimize:
                 case NativeMethods.ShowWindowCommands.ShowMinimized:
                     return WindowSizeState.Minimized;
-                case NativeMethods.ShowWindowCommands.Maximize
-                    : // No need for ShowMaximized here since its also of value 3
+                // No need for ShowMaximized here since its also of value 3
+                case NativeMethods.ShowWindowCommands.Maximize:
                     return WindowSizeState.Maximized;
                 default:
                     // throw new Exception("Don't know how to handle window state = " + placement.ShowCmd);

--- a/Main.cs
+++ b/Main.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Plugin.WindowWalker
             {
                 if (disposing)
                 {
-                    SettingWindow.Dispose();
+                    SettingWindow?.Dispose();
                 }
 
                 disposedValue = true;

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name":"Window Walker",
     "Description":"Alt-Tab alternative enabling searching through your windows.",
     "Author":"betadele",
-    "Version":"2.0.0",
+    "Version":"2.0.1",
     "Language":"csharp",
     "Website":"https://www.windowwalker.com/",
     "ExecuteFileName":"Microsoft.Plugin.WindowWalker.dll",


### PR DESCRIPTION
Previously owner check is comparing to null, which will be always false. 2.0.0 change that to IntPtr.Zero, but previously logic is wrong, which cause the issue in #21. This pr fix #21.

By the way, it is interesting that Flow Launcher won't be marked as owner. Flow itself is owned by an HWND wrapper, which is not visible, so Flow will not present on window list, which resolve #19 in a weird way.

Also, previous dispose contains a bug which will trigger nullreferenceexception when closing Flow, which is fixed.