### PR TITLE
Fix Quick Access Keyword assignment window & CI Publish workflow

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -25,7 +25,7 @@ jobs:
       - run: echo ${{steps.version.outputs.prop}} 
       - name: Build
         run: |
-          dotnet publish 'Microsoft.Plugin.WindowWalker.csproj' -r win-x64  -c Release -o "WindowWalker-${{steps.version.outputs.prop}}"
+          dotnet publish 'Flow.Plugin.WindowWalker.csproj' -r win-x64  -c Release -o "WindowWalker-${{steps.version.outputs.prop}}"
           7z a -tzip "WindowWalker-${{steps.version.outputs.prop}}.zip" "./WindowWalker-${{steps.version.outputs.prop}}/*"
           rm -r "WindowWalker-${{steps.version.outputs.prop}}"
       - name: Publish

--- a/Views/QuickAccessKeywordAssignedWindow.xaml
+++ b/Views/QuickAccessKeywordAssignedWindow.xaml
@@ -5,6 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:p="clr-namespace:Flow.Plugin.WindowWalker.Properties"
         mc:Ignorable="d"
+        WindowStartupLocation="CenterScreen"
         Loaded="OnLoad"
         Title="{x:Static p:Resources.quick_access_title}" Width="300" Height="240"
         DataContext="{Binding RelativeSource={RelativeSource Self}}">
@@ -18,12 +19,12 @@
             <ColumnDefinition/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
-        <StackPanel Grid.Row="0" Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left">
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Grid.ColumnSpan="2" Grid.Column="0" VerticalAlignment="Center" HorizontalAlignment="Left">
             <TextBlock Margin="20,0,0,0"
                        Text="{x:Static p:Resources.Window}"/>
             <TextBlock Margin="20,0,0,0"
                        Text="{Binding WindowName, Mode=OneTime}"
-                       Width="180"/>
+                       Width="auto"/>
         </StackPanel>
         <StackPanel Grid.Row="1" Grid.ColumnSpan="2" Grid.Column="0" VerticalAlignment="Center" Orientation="Horizontal">
             <TextBlock Margin="20,0,20,0"
@@ -37,8 +38,8 @@
                 PreviewKeyDown="KeywordBoxOnKeywordDown"
                 Name="KeywordBox"/>
         </StackPanel>
-        <StackPanel Grid.ColumnSpan="2" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Right" Grid.Row="2">
-            <Button Click="BtnCancel_OnClick" Margin="10 0 10 0" Width="80" Height="30"
+        <StackPanel Grid.ColumnSpan="2" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2">
+            <Button Click="BtnCancel_OnClick" Margin="75 0 10 0" Width="80" Height="30"
                     Content="{x:Static p:Resources.Cancel}"/>
             <Button Margin="10 0 10 0" Width="80" Height="30" Click="BtnDone_OnClick">
                 <TextBlock Text="{x:Static p:Resources.Done}" />


### PR DESCRIPTION
- Fix Quick Access Keyword assignment window

**Before:**

![image](https://user-images.githubusercontent.com/26427004/174193630-64cf8288-56b1-4373-9ea4-e966386fc14a.png)

**After, window is in the center position of the screen:**
![image](https://user-images.githubusercontent.com/26427004/174193868-da15a4ad-ea94-4ed8-9fac-038646acd685.png)

- CI Publish workflow