### PR TITLE
Update website and change to main maintainer

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,7 +3,7 @@
   "ActionKeywords": [ "*" ],
   "Name": "Window Walker",
   "Description": "Alt-Tab alternative enabling searching through your windows.",
-  "Author": "betadele",
+  "Author": "taooceros",
   "Version": "2.3.0",
   "Language": "csharp",
   "Website": "https://github.com/taooceros/Flow.Plugin.WindowWalker",


### PR DESCRIPTION
- windowwalker.com no longer works due to moving to PowerToys Run
- "original" repository depreciated
- fixes #24 